### PR TITLE
[WIP] Use transferFrom to repay flashloan

### DIFF
--- a/src/AgentImplementation.sol
+++ b/src/AgentImplementation.sol
@@ -109,8 +109,41 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
         _callbackWithCharge = _INIT_CALLBACK_WITH_CHARGE;
 
         // Execute logics with the charge fee flag
-        _executeLogics(logics, shouldChargeFeeByLogic);
+        // _executeLogics(logics, shouldChargeFeeByLogic);
+
+        uint256 logicsLength = logics.length;
+        for (uint256 i; i < logicsLength; ) {
+            ApproveHelper._approveMax(logics[i].to, address(bytes20(callbackWithCharge)), type(uint256).max);
+            unchecked {
+                ++i;
+            }
+        }
     }
+
+    // function executeByCallbackTransferFrom(IParam.Logic[] calldata logics, address[] calldata assets) external payable {
+    //     bytes32 callbackWithCharge = _callbackWithCharge;
+
+    //     // Revert if msg.sender is not equal to the callback address
+    //     if (msg.sender != address(bytes20(callbackWithCharge))) revert NotCallback();
+
+    //     // Check the least significant bit to determine whether to charge fee
+    //     bool shouldChargeFeeByLogic = (callbackWithCharge & _CHARGE_MASK) != bytes32(0);
+
+    //     // Reset immediately to prevent reentrancy
+    //     _callbackWithCharge = _INIT_CALLBACK_WITH_CHARGE;
+
+    //     // Execute logics with the charge fee flag
+    //     _executeLogics(logics, shouldChargeFeeByLogic);
+
+    //     // approve max to callback
+    //     uint256 assetsLength = assets.length;
+    //     for (uint256 i; i < assetsLength; ) {
+    //         ApproveHelper._approveMax(assets[i], address(bytes20(callbackWithCharge)), type(uint256).max);
+    //         unchecked {
+    //             ++i;
+    //         }
+    //     }
+    // }
 
     function _getBalance(address token) internal view returns (uint256 balance) {
         if (token == _NATIVE) {

--- a/src/AgentImplementation.sol
+++ b/src/AgentImplementation.sol
@@ -109,15 +109,15 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
         _callbackWithCharge = _INIT_CALLBACK_WITH_CHARGE;
 
         // Execute logics with the charge fee flag
-        // _executeLogics(logics, shouldChargeFeeByLogic);
+        _executeLogics(logics, shouldChargeFeeByLogic);
 
-        uint256 logicsLength = logics.length;
-        for (uint256 i; i < logicsLength; ) {
-            ApproveHelper._approveMax(logics[i].to, address(bytes20(callbackWithCharge)), type(uint256).max);
-            unchecked {
-                ++i;
-            }
-        }
+        // uint256 logicsLength = logics.length;
+        // for (uint256 i; i < logicsLength; ) {
+        //     ApproveHelper._approveMax(logics[i].to, address(bytes20(callbackWithCharge)), type(uint256).max);
+        //     unchecked {
+        //         ++i;
+        //     }
+        // }
     }
 
     // function executeByCallbackTransferFrom(IParam.Logic[] calldata logics, address[] calldata assets) external payable {

--- a/src/callbacks/AaveV2FlashLoanCallback.sol
+++ b/src/callbacks/AaveV2FlashLoanCallback.sol
@@ -58,13 +58,23 @@ contract AaveV2FlashLoanCallback is IAaveV2FlashLoanCallback {
             'ERROR_AAVE_V2_FLASH_LOAN_CALLBACK'
         );
 
+        // agent.functionCall(
+        //     abi.encodePacked(
+        //         IAgent.executeByCallbackTransferFrom.selector,
+        //         abi.encodePacked(params, abi.encode(assets))
+        //     ),
+        //     'ERROR_AAVE_V2_FLASH_LOAN_CALLBACK'
+        // );
+
         // Approve assets for pulling from Aave Pool
         for (uint256 i; i < assetsLength; ) {
             address asset = assets[i];
             uint256 amountOwing = amounts[i] + premiums[i];
 
+            // transferFrom
+            IERC20(asset).safeTransferFrom(agent, address(this), amountOwing);
             // Check balance is valid
-            if (IERC20(asset).balanceOf(address(this)) != initBalances[i] + amountOwing) revert InvalidBalance(asset);
+            // if (IERC20(asset).balanceOf(address(this)) != initBalances[i] + amountOwing) revert InvalidBalance(asset);
 
             // Save gas by only the first user does approve. It's safe since this callback don't hold any asset
             ApproveHelper._approveMax(asset, pool, amountOwing);

--- a/src/interfaces/IAgent.sol
+++ b/src/interfaces/IAgent.sol
@@ -33,4 +33,6 @@ interface IAgent {
     ) external payable;
 
     function executeByCallback(IParam.Logic[] calldata logics) external payable;
+
+    // function executeByCallbackTransferFrom(IParam.Logic[] calldata logics, address[] calldata assets) external payable;
 }

--- a/test/integration/AaveV2.t.sol
+++ b/test/integration/AaveV2.t.sol
@@ -220,6 +220,6 @@ contract AaveV2IntegrationTest is Test {
         }
 
         // Encode execute data
-        return abi.encode(logics, feesEmpty, tokensReturnEmpty);
+        return abi.encode(logics); //, feesEmpty, tokensReturnEmpty);
     }
 }

--- a/test/integration/AaveV2.t.sol
+++ b/test/integration/AaveV2.t.sol
@@ -211,7 +211,8 @@ contract AaveV2IntegrationTest is Test {
             // Encode transfering token + fee to the flash loan callback
             logics[i] = IParam.Logic(
                 address(tokens[i]), // to
-                abi.encodeWithSelector(IERC20.transfer.selector, address(flashLoanCallback), amounts[i] + fee),
+                // abi.encodeWithSelector(IERC20.transfer.selector, address(flashLoanCallback), amounts[i] + fee),
+                abi.encodeWithSelector(IERC20.approve.selector, address(flashLoanCallback), amounts[i] + fee),
                 inputsEmpty,
                 IParam.WrapMode.NONE,
                 address(0), // approveTo


### PR DESCRIPTION
AaveV2IntegrationTest::testExecuteAaveV2FlashLoan

|  | transfer  | transferFrom - inline approve | transferFrom - logic approve |
| -------------| ------------- | ------------- | ------------- |
| gas | 28567  | 26443 | 34058 |

單純模擬沒有執行 logics 的情況下，用 transfer & transferFrom 的 gas 消耗量
transfer gas 大約多 2k，猜測應該是因為 transfer 是包在 logic 裡面執行的，邏輯判斷上較多
但若是把 approve 包在 logic 裏面，gas 則會比 transfer 多大約 5.4k

另外若要採用 transferFrom 需特別注意 flashloan amount 不能為 0，否則在轉移 token 時會失敗 