### PR TITLE
Rename executeWithSignature to executeWithSignerFee

### DIFF
--- a/src/AgentImplementation.sol
+++ b/src/AgentImplementation.sol
@@ -81,7 +81,7 @@ contract AgentImplementation is IAgent, ERC721Holder, ERC1155Holder {
     /// @param logics Array of logics to be executed
     /// @param fees Array of fees
     /// @param tokensReturn Array of ERC-20 tokens to be returned to the current user
-    function executeWithSignature(
+    function executeWithSignerFee(
         IParam.Logic[] calldata logics,
         IParam.Fee[] calldata fees,
         address[] calldata tokensReturn

--- a/src/Router.sol
+++ b/src/Router.sol
@@ -117,7 +117,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         return result;
     }
 
-    /// @notice Add a signer whose signature can pass the validation in `executeWithSignature` by owner
+    /// @notice Add a signer whose signature can pass the validation in `executeWithSignerFee` by owner
     /// @param signer The signer address to be added
     function addSigner(address signer) external onlyOwner {
         signers[signer] = true;
@@ -139,14 +139,14 @@ contract Router is IRouter, EIP712, FeeGenerator {
         IERC20(token).safeTransfer(receiver, amount);
     }
 
-    /// @notice Pause `execute` and `executeWithSignature` by pauser
+    /// @notice Pause `execute` and `executeWithSignerFee` by pauser
     function pause() external onlyPauser {
         if (currentUser == _PAUSED) revert AlreadyPaused();
         currentUser = _PAUSED;
         emit Paused();
     }
 
-    /// @notice Unpause `execute` and `executeWithSignature` by pauser
+    /// @notice Unpause `execute` and `executeWithSignerFee` by pauser
     function unpause() external onlyPauser {
         if (currentUser != _PAUSED) revert NotPaused();
         currentUser = _INIT_CURRENT_USER;
@@ -184,7 +184,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
     /// @param signature The signer's signature bytes
     /// @param tokensReturn Array of ERC-20 tokens to be returned to the current user
     /// @param referralCode Referral code
-    function executeWithSignature(
+    function executeWithSignerFee(
         IParam.LogicBatch calldata logicBatch,
         address signer,
         bytes calldata signature,
@@ -205,7 +205,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         }
 
         emit Execute(user, address(agent), referralCode);
-        agent.executeWithSignature{value: msg.value}(logicBatch.logics, logicBatch.fees, tokensReturn);
+        agent.executeWithSignerFee{value: msg.value}(logicBatch.logics, logicBatch.fees, tokensReturn);
     }
 
     /// @notice Create an agent for `msg.sender`
@@ -240,7 +240,7 @@ contract Router is IRouter, EIP712, FeeGenerator {
         emit FeeCollectorSet(feeCollector_);
     }
 
-    /// @notice Set the pauser address that can pause `execute` and `executeWithSignature` by owner
+    /// @notice Set the pauser address that can pause `execute` and `executeWithSignerFee` by owner
     /// @param pauser_ The pauser address
     function setPauser(address pauser_) public onlyOwner {
         if (pauser_ == address(0)) revert InvalidNewPauser();

--- a/src/interfaces/IAgent.sol
+++ b/src/interfaces/IAgent.sol
@@ -26,7 +26,7 @@ interface IAgent {
 
     function execute(IParam.Logic[] calldata logics, address[] calldata tokensReturn) external payable;
 
-    function executeWithSignature(
+    function executeWithSignerFee(
         IParam.Logic[] calldata logics,
         IParam.Fee[] calldata fees,
         address[] calldata tokensReturn

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -83,7 +83,7 @@ interface IRouter {
         uint256 referralCode
     ) external payable;
 
-    function executeWithSignature(
+    function executeWithSignerFee(
         IParam.LogicBatch calldata logicBatch,
         address signer,
         bytes calldata signature,

--- a/test/Agent.t.sol
+++ b/test/Agent.t.sol
@@ -75,7 +75,7 @@ contract AgentTest is Test {
         vm.expectRevert(IAgent.NotRouter.selector);
         agent.execute(logicsEmpty, tokensReturnEmpty);
         vm.expectRevert(IAgent.NotRouter.selector);
-        agent.executeWithSignature(logicsEmpty, feesEmpty, tokensReturnEmpty);
+        agent.executeWithSignerFee(logicsEmpty, feesEmpty, tokensReturnEmpty);
         vm.stopPrank();
     }
 
@@ -122,7 +122,7 @@ contract AgentTest is Test {
         agent.execute(logics, tokensReturnEmpty);
     }
 
-    function testShouldNotChargeWhenExecuteWithSignature() external {
+    function testShouldNotChargeWhenExecuteWithSignerFee() external {
         // Invoke callback
         bytes memory data = abi.encodeWithSelector(IAgent.executeByCallback.selector, logicsEmpty);
         IParam.Logic[] memory logics = new IParam.Logic[](1);
@@ -137,7 +137,7 @@ contract AgentTest is Test {
         // Expected call to router::getFeeCalculator is 0 time
         vm.expectCall(router, abi.encode(IFeeGenerator.getFeeCalculator.selector), 0);
         vm.prank(router);
-        agent.executeWithSignature(logics, feesEmpty, tokensReturnEmpty);
+        agent.executeWithSignerFee(logics, feesEmpty, tokensReturnEmpty);
     }
 
     function testWrapBeforeFixedAmounts(uint128 amount1, uint128 amount2) external {

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -177,7 +177,7 @@ contract RouterTest is Test, LogicSignature {
         router.removeSigner(signer);
     }
 
-    function testExecuteWithSignature() external {
+    function testExecuteWithSignerFee() external {
         router.addSigner(signer);
 
         // Ensure correct EIP-712 encodeData for non-empty Input, Logic, Fee
@@ -206,7 +206,7 @@ contract RouterTest is Test, LogicSignature {
         vm.expectEmit(true, true, true, true, address(router));
         address calcAgent = router.calcAgent(user);
         emit Execute(user, calcAgent, SIGNER_REFERRAL);
-        router.executeWithSignature(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.executeWithSignerFee(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
         vm.stopPrank();
     }
 
@@ -219,9 +219,9 @@ contract RouterTest is Test, LogicSignature {
         vm.expectRevert(IRouter.NotReady.selector);
         router.execute(logicsEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
 
-        // `executeWithSignature` should revert when router is paused
+        // `executeWithSignerFee` should revert when router is paused
         vm.expectRevert(IRouter.NotReady.selector);
-        router.executeWithSignature(logicBatchEmpty, signer, new bytes(0), tokensReturnEmpty, SIGNER_REFERRAL);
+        router.executeWithSignerFee(logicBatchEmpty, signer, new bytes(0), tokensReturnEmpty, SIGNER_REFERRAL);
         vm.stopPrank();
     }
 
@@ -247,7 +247,7 @@ contract RouterTest is Test, LogicSignature {
 
         vm.expectRevert(abi.encodeWithSelector(IRouter.SignatureExpired.selector, deadline));
         vm.prank(user);
-        router.executeWithSignature(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.executeWithSignerFee(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
     }
 
     function testCannotExecuteInvalidSigner() external {
@@ -258,7 +258,7 @@ contract RouterTest is Test, LogicSignature {
 
         vm.expectRevert(abi.encodeWithSelector(IRouter.InvalidSigner.selector, signer));
         vm.prank(user);
-        router.executeWithSignature(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.executeWithSignerFee(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
     }
 
     function testCannotExecuteInvalidSignature() external {
@@ -273,14 +273,14 @@ contract RouterTest is Test, LogicSignature {
         logicBatch = IParam.LogicBatch(logicsEmpty, feesEmpty, deadline + 1);
         vm.prank(user);
         vm.expectRevert(IRouter.InvalidSignature.selector);
-        router.executeWithSignature(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.executeWithSignerFee(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
 
         // Tamper logics
         IParam.Logic[] memory logics = new IParam.Logic[](1);
         logicBatch = IParam.LogicBatch(logics, feesEmpty, deadline);
         vm.prank(user);
         vm.expectRevert(IRouter.InvalidSignature.selector);
-        router.executeWithSignature(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.executeWithSignerFee(logicBatch, signer, signature, tokensReturnEmpty, SIGNER_REFERRAL);
     }
 
     function testSetPauser(address pauser_) external {

--- a/test/invariants/AgentInvariants.t.sol
+++ b/test/invariants/AgentInvariants.t.sol
@@ -46,15 +46,15 @@ contract AgentInvariants is Test {
     function invariant_callSummary() external view {
         uint256 numExecute = agentHandler.numCalls('execute');
         uint256 numExecuteWithoutCallback = agentHandler.numCalls('executeWithoutCallback');
-        uint256 numExecuteWithSignature = agentHandler.numCalls('executeWithSignature');
+        uint256 numExecuteWithSignerFee = agentHandler.numCalls('executeWithSignerFee');
         uint256 numExecuteByCallback = agentHandler.numCalls('executeByCallback');
 
         console2.log('\nCall Summary\n');
         console2.log('execute', numExecute);
         console2.log('executeWithoutCallback', numExecuteWithoutCallback);
-        console2.log('executeWithSignature', numExecuteWithSignature);
+        console2.log('executeWithSignerFee', numExecuteWithSignerFee);
         console2.log('executeByCallback', numExecuteByCallback);
         console2.log('------------------');
-        console2.log('Sum', numExecute + numExecuteWithoutCallback + numExecuteWithSignature + numExecuteByCallback);
+        console2.log('Sum', numExecute + numExecuteWithoutCallback + numExecuteWithSignerFee + numExecuteByCallback);
     }
 }

--- a/test/invariants/RouterInvariants.t.sol
+++ b/test/invariants/RouterInvariants.t.sol
@@ -17,7 +17,7 @@ contract RouterInvariantsTest is Test {
 
         bytes4[] memory selectors = new bytes4[](4);
         selectors[0] = RouterHandler.execute.selector;
-        selectors[1] = RouterHandler.executeWithSignature.selector;
+        selectors[1] = RouterHandler.executeWithSignerFee.selector;
         selectors[2] = RouterHandler.newAgent.selector;
         selectors[3] = RouterHandler.newAgentFor.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));

--- a/test/invariants/handlers/AgentHandler.sol
+++ b/test/invariants/handlers/AgentHandler.sol
@@ -40,10 +40,10 @@ contract AgentHandler is Test {
         IMockAgent(agent).execute(logicsEmpty, tokensReturnEmpty);
     }
 
-    function executeWithSignature() external {
-        numCalls['executeWithSignature']++;
+    function executeWithSignerFee() external {
+        numCalls['executeWithSignerFee']++;
         vm.prank(router);
-        IMockAgent(agent).executeWithSignature(_logicsWithCallback(), feesEmpty, tokensReturnEmpty);
+        IMockAgent(agent).executeWithSignerFee(_logicsWithCallback(), feesEmpty, tokensReturnEmpty);
     }
 
     function executeByCallback() external {

--- a/test/invariants/handlers/RouterHandler.sol
+++ b/test/invariants/handlers/RouterHandler.sol
@@ -81,7 +81,7 @@ contract RouterHandler is Test, LogicSignature {
     function callSummary() external view {
         console2.log('\nCall Summary\n');
         console2.log('execute', calls['execute']);
-        console2.log('executeWithSignature', calls['executeWithSignature']);
+        console2.log('executeWithSignerFee', calls['executeWithSignerFee']);
         console2.log('newAgent', calls['newAgent']);
         console2.log('newAgentFor', calls['newAgentFor']);
         console2.log('actorsNum', calls['actorsNum']);
@@ -92,14 +92,14 @@ contract RouterHandler is Test, LogicSignature {
         router.execute(logicsEmpty, tokensReturnEmpty, SIGNER_REFERRAL);
     }
 
-    function executeWithSignature(
+    function executeWithSignerFee(
         uint256 actorSeed
-    ) external useActor(actorSeed) recordAgent countCall('executeWithSignature') {
+    ) external useActor(actorSeed) recordAgent countCall('executeWithSignerFee') {
         vm.startPrank(currentActor);
         uint256 deadline = block.timestamp;
         IParam.LogicBatch memory logicBatch = IParam.LogicBatch(logicsEmpty, feesEmpty, deadline);
         bytes memory sigature = getLogicBatchSignature(logicBatch, router.domainSeparator(), signerPrivateKey);
-        router.executeWithSignature(logicBatch, signer, sigature, tokensReturnEmpty, SIGNER_REFERRAL);
+        router.executeWithSignerFee(logicBatch, signer, sigature, tokensReturnEmpty, SIGNER_REFERRAL);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
This naming avoids confusion with commonly used terms such as `WithSig` or `WithSignature`.