### PR TITLE
refine: sc improvements

### DIFF
--- a/src/libraries/Delegation.sol
+++ b/src/libraries/Delegation.sol
@@ -4,14 +4,12 @@ pragma solidity ^0.8.0;
 import {DataType} from '../libraries/DataType.sol';
 
 library Delegation {
-    /// @notice Set the expiry and nonce of the delegatee set by user.
+    /// @notice Set the expiry and nonce of the delegatee.
     function updateAll(DataType.PackedDelegation storage delegated, uint128 expiry, uint128 nonce) internal {
-        uint128 storedNonce;
+        uint256 word;
         unchecked {
-            storedNonce = nonce + 1;
+            word = _pack(expiry, nonce + 1);
         }
-        uint128 storedExpiry = expiry;
-        uint256 word = _pack(storedExpiry, storedNonce);
         assembly {
             sstore(delegated.slot, word)
         }


### PR DESCRIPTION
- [x] Remove redundant uint256 casting
- [x] Remove redundant assignment of nonce variable when verifying the signature
- [x] Add delegate before executeFor notice
- [x] Delegation updateAll word & notice
- [x] Unchecked in nonce calculation 