### PR TITLE
Deploy Router on Goerli

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,5 @@ optimizer_runs = 10_000
 
 [rpc_endpoints]
 ethereum = "https://cloudflare-eth.com"
-arbitrum = "https://arb1.arbitrum.io/rpc"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/script/DeployGoerli.s.sol
+++ b/script/DeployGoerli.s.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {DeployRouter} from './DeployRouter.s.sol';
+
+contract DeployGoerli is DeployRouter {
+    address public constant DEPLOYER = 0xBcb909975715DC8fDe643EE44b89e3FD6A35A259;
+    address public constant OWNER = 0xBcb909975715DC8fDe643EE44b89e3FD6A35A259;
+    address public constant PAUSER = 0xBcb909975715DC8fDe643EE44b89e3FD6A35A259;
+    address public constant DEFAULT_COLLECTOR = 0xBcb909975715DC8fDe643EE44b89e3FD6A35A259;
+    address public constant CREATE3_FACTORY = 0xFa3e9a110E6975ec868E9ed72ac6034eE4255B64;
+
+    /// @notice Set up deploy parameters and deploy contracts whose `deployedAddress` equals `UNDEPLOYED`.
+    function setUp() external {
+        routerConfig = RouterConfig({
+            deployedAddress: 0xDec80E988F4baF43be69c13711453013c212feA8,
+            wrappedNative: 0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6,
+            permit2: 0x000000000022D473030F116dDEE9F6B43aC78BA3,
+            deployer: DEPLOYER,
+            owner: OWNER,
+            pauser: PAUSER,
+            defaultCollector: DEFAULT_COLLECTOR,
+            signer: 0xffFf5a88840FF1f168E163ACD771DFb292164cFA,
+            feeRate: 20
+        });
+    }
+
+    function _run() internal override {
+        // router
+        _deployRouter(CREATE3_FACTORY);
+    }
+}

--- a/test/callbacks/AaveV2FlashLoanCallback.t.sol
+++ b/test/callbacks/AaveV2FlashLoanCallback.t.sol
@@ -23,7 +23,7 @@ contract AaveV2FlashLoanCallbackTest is Test {
     DataType.Input[] public inputsEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         defaultCollector = makeAddr('defaultCollector');

--- a/test/callbacks/AaveV3FlashLoanCallback.t.sol
+++ b/test/callbacks/AaveV3FlashLoanCallback.t.sol
@@ -23,7 +23,7 @@ contract AaveV3FlashLoanCallbackTest is Test {
     DataType.Input[] public inputsEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         defaultCollector = makeAddr('defaultCollector');

--- a/test/callbacks/BalancerV2FlashLoanCallback.t.sol
+++ b/test/callbacks/BalancerV2FlashLoanCallback.t.sol
@@ -23,7 +23,7 @@ contract BalancerV2FlashLoanCallbackTest is Test {
     DataType.Input[] public inputsEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         defaultCollector = makeAddr('defaultCollector');

--- a/test/callbacks/RadiantV2FlashLoanCallback.t.sol
+++ b/test/callbacks/RadiantV2FlashLoanCallback.t.sol
@@ -9,7 +9,7 @@ import {IAaveV2FlashLoanCallback, IAaveV2Provider} from 'src/callbacks/RadiantV2
 import {RadiantV2FlashLoanCallback} from 'src/callbacks/RadiantV2FlashLoanCallback.sol';
 
 contract RadiantV2FlashLoanCallbackTest is Test {
-    IAaveV2Provider public constant radiantV2Provider = IAaveV2Provider(0x091d52CacE1edc5527C99cDCFA6937C1635330E4);
+    IAaveV2Provider public constant radiantV2Provider = IAaveV2Provider(0x70e507f1d20AeC229F435cd1EcaC6A7200119B9F);
     uint256 public constant BPS_BASE = 10_000;
 
     address public user;
@@ -24,7 +24,7 @@ contract RadiantV2FlashLoanCallbackTest is Test {
     DataType.Input[] public inputsEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('arbitrum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         defaultCollector = makeAddr('defaultCollector');

--- a/test/callbacks/SparkFlashLoanCallback.t.sol
+++ b/test/callbacks/SparkFlashLoanCallback.t.sol
@@ -23,7 +23,7 @@ contract SparkFlashLoanCallbackTest is Test {
     DataType.Input[] public inputsEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         defaultCollector = makeAddr('defaultCollector');

--- a/test/integration/AaveV2.t.sol
+++ b/test/integration/AaveV2.t.sol
@@ -67,7 +67,7 @@ contract AaveV2IntegrationTest is Test {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         router = new Router(makeAddr('WrappedNative'), permit2Addr, address(this));

--- a/test/integration/AaveV3.t.sol
+++ b/test/integration/AaveV3.t.sol
@@ -68,7 +68,7 @@ contract AaveV3IntegrationTest is Test {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         router = new Router(makeAddr('WrappedNative'), makeAddr('Permit2'), address(this));

--- a/test/integration/BalancerV2.t.sol
+++ b/test/integration/BalancerV2.t.sol
@@ -31,7 +31,7 @@ contract BalancerV2IntegrationTest is Test {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         router = new Router(makeAddr('WrappedNative'), makeAddr('Permit2'), address(this));

--- a/test/integration/ERC1155Market.t.sol
+++ b/test/integration/ERC1155Market.t.sol
@@ -30,7 +30,7 @@ contract ERC1155MarketTest is Test, ERC20Permit2Utils, ERC1155Utils {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         (user, userPrivateKey) = makeAddrAndKey('User');
         router = new Router(makeAddr('WrappedNative'), permit2Addr, address(this));

--- a/test/integration/ERC721Market.t.sol
+++ b/test/integration/ERC721Market.t.sol
@@ -30,7 +30,7 @@ contract ERC721MarketTest is Test, ERC20Permit2Utils, ERC721Utils {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         (user, userPrivateKey) = makeAddrAndKey('User');
         router = new Router(makeAddr('WrappedNative'), permit2Addr, address(this));

--- a/test/integration/RadiantV2.t.sol
+++ b/test/integration/RadiantV2.t.sol
@@ -31,9 +31,9 @@ contract RadiantV2IntegrationTest is Test {
         VARIABLE
     }
 
-    IAaveV2Provider public constant RADIANT_V2_PROVIDER = IAaveV2Provider(0x091d52CacE1edc5527C99cDCFA6937C1635330E4);
-    IERC20 public constant USDC = IERC20(0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8);
-    address public constant RUSDC_V2 = 0x48a29E756CC1C097388f3B2f3b570ED270423b3d;
+    IAaveV2Provider public constant RADIANT_V2_PROVIDER = IAaveV2Provider(0x70e507f1d20AeC229F435cd1EcaC6A7200119B9F);
+    IERC20 public constant USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    address public constant RUSDC_V2 = 0x9E85DF2B42b2aE5e666D7263ED81a744a534BF1f;
     address internal constant permit2Addr = address(0x000000000022D473030F116dDEE9F6B43aC78BA3);
 
     address public user;
@@ -48,7 +48,7 @@ contract RadiantV2IntegrationTest is Test {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('arbitrum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         router = new Router(makeAddr('WrappedNative'), permit2Addr, address(this));

--- a/test/integration/Spark.t.sol
+++ b/test/integration/Spark.t.sol
@@ -48,7 +48,7 @@ contract SparkIntegrationTest is Test {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         router = new Router(makeAddr('WrappedNative'), makeAddr('Permit2'), address(this));

--- a/test/integration/UniswapV2.t.sol
+++ b/test/integration/UniswapV2.t.sol
@@ -69,7 +69,7 @@ contract UniswapV2Test is Test, ERC20Permit2Utils {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         (user, userPrivateKey) = makeAddrAndKey('User');
         router = new Router(address(WRAPPED_NATIVE), address(PERMIT2), address(this));

--- a/test/integration/UniswapV3.t.sol
+++ b/test/integration/UniswapV3.t.sol
@@ -121,7 +121,7 @@ contract UniswapV3Test is Test, ERC20Permit2Utils, ERC721Utils {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         (user, userPrivateKey) = makeAddrAndKey('User');
         router = new Router(makeAddr('WrappedNative'), permit2Addr, address(this));

--- a/test/integration/WrappedNative.t.sol
+++ b/test/integration/WrappedNative.t.sol
@@ -21,7 +21,7 @@ contract WrappedNativeTest is Test {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         router = new Router(address(WRAPPED_NATIVE), address(PERMIT2), address(this));

--- a/test/integration/YearnV2.t.sol
+++ b/test/integration/YearnV2.t.sol
@@ -29,7 +29,7 @@ contract YearnV2Test is Test, ERC20Permit2Utils {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         (user, userPrivateKey) = makeAddrAndKey('User');
         router = new Router(makeAddr('WrappedNative'), permit2Addr, address(this));

--- a/test/integration/fee/AaveFlashLoanFeeCharging.t.sol
+++ b/test/integration/fee/AaveFlashLoanFeeCharging.t.sol
@@ -60,7 +60,7 @@ contract AaveFlashLoanFeeCalculatorTest is Test {
     bytes[] public datasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         defaultCollector = makeAddr('FeeCollector');

--- a/test/integration/fee/BalancerFlashLoanFeeCharging.t.sol
+++ b/test/integration/fee/BalancerFlashLoanFeeCharging.t.sol
@@ -45,7 +45,7 @@ contract BalancerFlashLoanFeeCalculatorTest is Test {
     bytes[] public datasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         user2 = makeAddr('User2');

--- a/test/integration/fee/NativeFeeCharging.t.sol
+++ b/test/integration/fee/NativeFeeCharging.t.sol
@@ -30,7 +30,7 @@ contract NativeFeeCalculatorTest is Test {
     bytes[] public datasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         receiver = makeAddr('Receiver');

--- a/test/integration/fee/Permit2FeeCharging.t.sol
+++ b/test/integration/fee/Permit2FeeCharging.t.sol
@@ -35,7 +35,7 @@ contract Permit2FeeCalculatorTest is Test, ERC20Permit2Utils, TypedDataSignature
     bytes32[] public referralsEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
         TypedDataSignature.initialize();
 
         (user, userPrivateKey) = makeAddrAndKey('User');

--- a/test/integration/fee/RadiantFlashLoanFeeCharging.t.sol
+++ b/test/integration/fee/RadiantFlashLoanFeeCharging.t.sol
@@ -24,9 +24,9 @@ contract RadiantFlashLoanFeeCalculatorTest is Test {
     event Charged(address indexed token, uint256 amount, address indexed collector, bytes32 metadata);
 
     address public constant NATIVE = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    address public constant RADIANT_V2_PROVIDER = 0x091d52CacE1edc5527C99cDCFA6937C1635330E4;
-    address public constant USDC = 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8;
-    address public constant RUSDC_V2 = 0x48a29E756CC1C097388f3B2f3b570ED270423b3d;
+    address public constant RADIANT_V2_PROVIDER = 0x70e507f1d20AeC229F435cd1EcaC6A7200119B9F;
+    address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address public constant RUSDC_V2 = 0x9E85DF2B42b2aE5e666D7263ED81a744a534BF1f;
     address public constant PERMIT2_ADDRESS = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
     bytes4 public constant RADIANT_FLASHLOAN_SELECTOR =
         bytes4(keccak256(bytes('flashLoan(address,address[],uint256[],uint256[],address,bytes,uint16)')));
@@ -50,7 +50,7 @@ contract RadiantFlashLoanFeeCalculatorTest is Test {
     bytes[] public datasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('arbitrum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         defaultCollector = makeAddr('FeeCollector');

--- a/test/integration/maker/AgentMakerAction.t.sol
+++ b/test/integration/maker/AgentMakerAction.t.sol
@@ -37,7 +37,7 @@ contract AgentMakerActionTest is Test, MakerCommonUtils, ERC20Permit2Utils {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         user = makeAddr('User');
         (user2, user2PrivateKey) = makeAddrAndKey('User2');

--- a/test/integration/maker/MakerUtility.t.sol
+++ b/test/integration/maker/MakerUtility.t.sol
@@ -30,7 +30,7 @@ contract MakerUtilityTest is Test, MakerCommonUtils, ERC20Permit2Utils {
     bytes[] public permit2DatasEmpty;
 
     function setUp() external {
-        vm.createSelectFork(vm.rpcUrl('ethereum'));
+        vm.createSelectFork(vm.rpcUrl('ethereum'), 18860000);
 
         (user, userPrivateKey) = makeAddrAndKey('User');
         router = new Router(makeAddr('WrappedNative'), permit2Addr, address(this));


### PR DESCRIPTION
- Goerli deployment is added for Morpho Blue.
- Since the aave-v3 USDC cap is full, the test is pinned to a block for integration testing near the v1.0.0 release on 2023/12/25.
- Radiant can also be tested on Ethereum instead, as arbitrum is lack of archive node.